### PR TITLE
feat: rm mint_with_json, use borsh serialization

### DIFF
--- a/.config.js
+++ b/.config.js
@@ -37,7 +37,7 @@ module.exports = {
     ethNodeUrl: 'https://rinkeby.infura.io/v3/TODO',
     ethProverAddress: '0xc5D62d66B8650E6242D9936c7e50E959BA0F9E37',
     nearClientAccount: 'ethonnearclient10',
-    nearFunTokenAccount: 'mint_with_json-workaround-for-mintablefuntoken.chad',
+    nearFunTokenAccount: 'mintable-fungible-token.chad',
     nearHelperUrl: 'https://helper.testnet.near.org/',
     nearNetworkId: 'testnet',
     nearNodeUrl: 'https://rpc.testnet.near.org',

--- a/README.md
+++ b/README.md
@@ -95,17 +95,13 @@ To run this project locally:
 
 3. Follow the instructions for [rainbow-bridge-cli](https://github.com/near/rainbow-bridge-cli) to run an Ethereum network, a NEAR network, and the bridge all locally
 
-4. Clone [rainbow-bridge-rs](https://github.com/near/rainbow-bridge-rs) and checkout [this branch](https://github.com/near/rainbow-bridge-rs/pull/8), and deploy it to your locally-running NEAR network. You will need to copy the private key for `nearfuntoken` from `~/.rainbow/config.json` to `~/.near-credentials/localnet/nearfuntoken.json`, then you can deploy it with:
+4. Run [near-contract-helper](https://github.com/near/near-contract-helper) locally on the default port (3000)
 
-      NEAR_ENV=local near deploy -v --contractName nearfuntoken --wasmFile res/mintable_fungible_token.wasm --keyPath ~/.near-credentials/localnet/nearfuntoken.json
-
-5. Run [near-contract-helper](https://github.com/near/near-contract-helper) locally on the default port (3000)
-
-6. Run [near-wallet](https://github.com/near/near-wallet) locally ([this PR](https://github.com/near/near-wallet/pull/861) streamlines it). Run it on port 4000 & set node's `--max-http-header-size` to `16000` (default is 8kb):
+5. Run [near-wallet](https://github.com/near/near-wallet) locally ([this PR](https://github.com/near/near-wallet/pull/861) streamlines it). Run it on port 4000 & set node's `--max-http-header-size` to `16000` (default is 8kb):
 
        yarn update:static; node --max-http-header-size=16000 ./node_modules/.bin/parcel -p 4000 src/index.html
 
-7. Run the local development server: `yarn local` (see `package.json` for a full list of `scripts` you can run with `yarn`; see `.config.js` to see how environment variables are loaded in)
+6. Run the local development server: `yarn local` (see `package.json` for a full list of `scripts` you can run with `yarn`; see `.config.js` to see how environment variables are loaded in)
 
   [ERC20]: https://eips.ethereum.org/EIPS/eip-20
   [Rainbow Bridge]: https://github.com/near/rainbow-bridge

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eth-object": "near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7",
     "eth-revert-reason": "^1.0.3",
     "eth-util-lite": "near/eth-util-lite#master",
-    "near-api-js": "^0.27.0",
+    "near-api-js": "near/near-api-js#allow-borsh-serialization",
     "promisfy": "^1.2.0",
     "ulid": "^2.3.0",
     "web3": "^1.2.11",

--- a/src/js/authNear.js
+++ b/src/js/authNear.js
@@ -39,8 +39,7 @@ async function login () {
     {
       // View methods are read only
       viewMethods: ['get_balance'],
-      // Change methods modify state but don't receive updated data
-      changeMethods: ['mint_with_json']
+      changeMethods: ['mint']
     }
   )
 

--- a/src/js/borsh/mintableTokenFactory.js
+++ b/src/js/borsh/mintableTokenFactory.js
@@ -1,0 +1,19 @@
+export class Proof {
+  constructor (proof) {
+    Object.assign(this, proof)
+  }
+}
+
+export const schema = new Map([
+  [Proof, {
+    kind: 'struct',
+    fields: [
+      ['log_index', 'u64'],
+      ['log_entry_data', ['u8']],
+      ['receipt_index', 'u64'],
+      ['receipt_data', ['u8']],
+      ['header_data', ['u8']],
+      ['proof', [['u8']]]
+    ]
+  }]
+])

--- a/src/js/transfers.js
+++ b/src/js/transfers.js
@@ -8,6 +8,11 @@ import { ulid } from 'ulid'
 import utils from 'ethereumjs-util'
 import * as urlParams from './urlParams'
 import getRevertReason from 'eth-revert-reason'
+import { serialize as serializeBorsh } from 'near-api-js/lib/utils/serialize'
+import {
+  Proof as BorshProof,
+  schema as proofBorshSchema
+} from './borsh/mintableTokenFactory'
 
 // Initiate a new transfer of 'amount' ERC20 tokens to NEAR.
 // Currently depends on many global variables:
@@ -345,8 +350,8 @@ async function mint (transfer) {
 
   const proof = await findProof(transfer)
 
-  await window.nep21.mint_with_json(
-    { proof },
+  await window.nep21.mint(
+    serializeBorsh(proofBorshSchema, proof),
     new BN('300000000000000'),
     // We need to attach tokens because minting increases the contract state, by <600 bytes, which
     // requires an additional 0.06 NEAR to be deposited to the account for state staking.
@@ -378,14 +383,14 @@ async function findProof (transfer) {
   )
   const log = receipt.logs[logIndexInArray]
 
-  return {
+  return new BorshProof({
     log_index: logIndexInArray,
     log_entry_data: Array.from(Log.fromWeb3(log).serialize()),
     receipt_index: proof.txIndex,
     receipt_data: Array.from(Receipt.fromWeb3(receipt).serialize()),
     header_data: Array.from(proof.header_rlp),
     proof: Array.from(proof.receiptProof).map(utils.rlp.encode).map(b => Array.from(b))
-  }
+  })
 }
 
 async function buildTree (block) {


### PR DESCRIPTION
This removes the need for a forked contract

Relies on https://github.com/near/near-api-js/pull/426